### PR TITLE
make the image name not match the deployment name, for clarity

### DIFF
--- a/0-base/Tiltfile
+++ b/0-base/Tiltfile
@@ -1,3 +1,3 @@
+docker_build('example-html-image', '.')
 k8s_yaml('kubernetes.yaml')
-docker_build('example-html', '.')
 k8s_resource('example-html', port_forwards=8000)

--- a/0-base/kubernetes.yaml
+++ b/0-base/kubernetes.yaml
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
       - name: example-html
-        image: example-html
+        image: example-html-image
         ports:
         - containerPort: 8000

--- a/1-measured/Tiltfile
+++ b/1-measured/Tiltfile
@@ -1,5 +1,5 @@
+docker_build('example-html-image', '.')
 k8s_yaml('kubernetes.yaml')
-docker_build('example-html', '.')
 k8s_resource('example-html', port_forwards=8000, resource_deps=['deploy'])
 
 # Records the start time.

--- a/1-measured/kubernetes.yaml
+++ b/1-measured/kubernetes.yaml
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
       - name: example-html
-        image: example-html
+        image: example-html-image
         ports:
         - containerPort: 8000

--- a/2-recommended/Tiltfile
+++ b/2-recommended/Tiltfile
@@ -9,7 +9,7 @@ local_resource(
   trigger_mode=TRIGGER_MODE_MANUAL)
 
 # Add a live_update rule to our docker_build.
-docker_build('example-html', '.', live_update=[
+docker_build('example-html-image', '.', live_update=[
   sync('.', '/app'),
   run('./report-deployment-time.sh'),
 ])

--- a/2-recommended/kubernetes.yaml
+++ b/2-recommended/kubernetes.yaml
@@ -15,6 +15,6 @@ spec:
     spec:
       containers:
       - name: example-html
-        image: example-html
+        image: example-html-image
         ports:
         - containerPort: 8000


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/image:

21ef645b271cc4d8e26ac8b5a51696731ae13882 (2020-02-27 18:35:01 -0500)
make the image name not match the deployment name, for clarity

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics