### PR TITLE
circleci to use latest tilt image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: tiltdev/circleci-tilt:v0.13.0
+      - image: tiltdev/tilt:latest
 
     steps:
       - setup_remote_docker


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/config:

af206462e8a84c62f874df7a216f1c5bb297e933 (2020-04-14 13:56:37 -0400)
circleci to use latest tilt image

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics