### PR TITLE
omit the trailing newline when printing time

### DIFF
--- a/1-measured/report-deployment-time.sh
+++ b/1-measured/report-deployment-time.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 DEPLOY_TIME_SEC=$(date +%s)
-DEPLOY_DURATION_SEC=$(expr $DEPLOY_TIME_SEC - $(cat start-time.txt))
+DEPLOY_DURATION_SEC=$(expr $DEPLOY_TIME_SEC - $(cat start-time.txt | tr -d "[:space:]"))
 echo "Deploy time in seconds: $DEPLOY_DURATION_SEC"
 sed -i "s/^.*Deploy.*$/<div>Deploy time: $DEPLOY_DURATION_SEC sec/g" index.html

--- a/2-recommended/report-deployment-time.sh
+++ b/2-recommended/report-deployment-time.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 DEPLOY_TIME_SEC=$(date +%s)
-DEPLOY_DURATION_SEC=$(expr $DEPLOY_TIME_SEC - $(cat start-time.txt))
+DEPLOY_DURATION_SEC=$(expr $DEPLOY_TIME_SEC - $(cat start-time.txt | tr -d "[:space:]"))
 echo "Deploy time in seconds: $DEPLOY_DURATION_SEC"
 sed -i "s/^.*Deploy.*$/<div>Deploy time: $DEPLOY_DURATION_SEC sec/g" index.html


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/windows:

faa78708efb7111b4c4ebc5abfde41ad309478fc (2020-05-13 15:46:47 -0400)
omit the trailing newline when printing time

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics